### PR TITLE
Fix on Gnome 42

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -2,6 +2,9 @@
 	"extension": "datetime-format",
 	"domain": "Daniel-Khodabakhsh.github.com",
 	"description": "Allow users to customise the datetime format on the clock panel and lock screen.",
-	"gnomeShellVersions": ["40.0"],
+	"gnomeShellVersions": [
+		"40.0",
+		"42.0"
+	],
 	"url": "https://github.com/Daniel-Khodabakhsh/datetime-format"
 }

--- a/src/EditWindow.js
+++ b/src/EditWindow.js
@@ -10,7 +10,7 @@
 /// @param {Settings} settings - Settings object.
 /// @param {Object} language - Language map.
 /// 
-const Class = function (parent, gladeFile, settings, language) {
+var Class = function (parent, gladeFile, settings, language) {
 	const GLib = imports.gi.GLib;
 	const Utilities = imports.misc.extensionUtils.getCurrentExtension().imports.Utilities;
 

--- a/src/EditWindow.js
+++ b/src/EditWindow.js
@@ -108,7 +108,7 @@ var Class = function (parent, gladeFile, settings, language) {
 	///
 	this.showWindow = function (formatTarget, formatTargetObject, updateParentPreview, name) {
 		title.set_text(name + " - " + language.format);
-		window.set_transient_for(parent.get_parent().get_parent());
+		window.set_transient_for(parent.get_root());
 		formatEntry.set_text(settings.getFormat(formatTarget));
 		formatEntry.select_region(0, -1);
 		formatEntry.grab_focus();

--- a/src/FormatTarget.js
+++ b/src/FormatTarget.js
@@ -59,5 +59,5 @@ const create = function (container, formatTarget, builder, settings, editWindow)
 		editWindow.showWindow(formatTarget, formatTargetObject, updatePreview, name);
 	});
 
-	container.append(builder.get_object("formatTargetBox"), false, true, 0);
+	container.append(builder.get_object("formatTargetBox"));
 };

--- a/src/FormatTarget.js
+++ b/src/FormatTarget.js
@@ -11,7 +11,7 @@
 /// @param {Settings} settings - Settings object.
 /// @param {EditWindow} editWindow - Edit window to show when the settings button is pressed.
 ///
-const create = function (container, formatTarget, builder, settings, editWindow) {
+var create = function (container, formatTarget, builder, settings, editWindow) {
 	const GLib = imports.gi.GLib;
 	const extension = imports.misc.extensionUtils.getCurrentExtension();
 	const formatTargetObject = extension.imports.formatTargets[formatTarget];

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -5,7 +5,7 @@
 ///
 /// Settings constructor.
 ///
-const Class = function () {
+var Class = function () {
 	const Gio = imports.gi.Gio;
 	const extension = imports.misc.extensionUtils.getCurrentExtension();
 

--- a/src/formatTargets/DateMenuDate.js
+++ b/src/formatTargets/DateMenuDate.js
@@ -4,7 +4,7 @@ const name = {
 	ja: "日付メニュー：日付"
 };
 
-const defaultFormat = "%B %e %Y";
+var defaultFormat = "%B %e %Y";
 
 let dateLabel;
 let dateTimeDisplay;

--- a/src/formatTargets/DateMenuDate.js
+++ b/src/formatTargets/DateMenuDate.js
@@ -1,4 +1,4 @@
-const name = {
+var name = {
 	en: "Date Menu: Date",
 	fr: "Menu de date: Date",
 	ja: "日付メニュー：日付"

--- a/src/formatTargets/DateMenuDay.js
+++ b/src/formatTargets/DateMenuDay.js
@@ -1,4 +1,4 @@
-const name = {
+var name = {
 	en: "Date Menu: Day",
 	fr: "Menu de date: Jour",
 	ja: "日付メニュー：日"

--- a/src/formatTargets/DateMenuDay.js
+++ b/src/formatTargets/DateMenuDay.js
@@ -4,7 +4,7 @@ const name = {
 	ja: "日付メニュー：日"
 };
 
-const defaultFormat = "%A";
+var defaultFormat = "%A";
 
 let dayLabel;
 let dateTimeDisplay;

--- a/src/formatTargets/StatusBar.js
+++ b/src/formatTargets/StatusBar.js
@@ -4,7 +4,7 @@ const name = {
 	ja: "ステータスバー"
 };
 
-const defaultFormat = "%c";
+var defaultFormat = "%c";
 
 let clockDisplay;
 let dateTimeDisplay;

--- a/src/formatTargets/StatusBar.js
+++ b/src/formatTargets/StatusBar.js
@@ -1,4 +1,4 @@
-const name = {
+var name = {
 	en: "Status Bar",
 	fr: "Barre d'état",
 	ja: "ステータスバー"

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -4,6 +4,7 @@
 
 const Gtk = imports.gi.Gtk;
 const GLib = imports.gi.GLib;
+const ByteArray = imports.byteArray;
 const extension = imports.misc.extensionUtils.getCurrentExtension();
 const Utilities = extension.imports.Utilities;
 
@@ -83,7 +84,7 @@ function fileExists(file) {
 /// @return {string} File contents.
 ///
 function readFile(file) {
-	return String(GLib.file_get_contents(filePath(file))[1]);
+	return ByteArray.toString(GLib.file_get_contents(filePath(file))[1]);
 }
 
 ///


### PR DESCRIPTION
Extends from https://github.com/Daniel-Khodabakhsh/datetime-format/pull/20.

The extension wasn't working at all on Gnome 42. This PR resolves that, containing various fixes and also addresses deprecation warnings - see each commit for details.

The errors & warnings were uncovered using `journalctl -f /usr/bin/gnome-shell /usr/bin/gjs`. It took me a little while to discover the latter filter; once I got the preferences window able to show, the edit buttons didn't do anything and weren't showing a UI error.

It didn't seem like this part of the deprecation warning was actually true:

> The property access will work as previously for the time being, but please fix your code anyway.

I realise we're a few fork in at this point, but with this repo being the most progressed, it seemed like the place to make the changes =P